### PR TITLE
enable WalletConnect to help with mobile

### DIFF
--- a/src/components/WalletProviderModal/WalletProviderModal.tsx
+++ b/src/components/WalletProviderModal/WalletProviderModal.tsx
@@ -35,6 +35,11 @@ const WalletProviderModal: React.FC<ModalProps> = ({ onDismiss }) => {
 							onConnect={() => connect('injected')}
 							title="Metamask"
 						/>
+						<WalletCard
+							icon={<img src={walletConnectLogo} style={{height: 32}} />}
+							onConnect={() => connect('walletconnect')}
+							title="WalletConnect"
+						/>
 					</StyledWalletCard>
 					<Spacer size="sm" />
 				</StyledWalletsWrapper>


### PR DESCRIPTION
Since MetaMask connect doesn't appear to work on mobile, this may help bridge the gap.